### PR TITLE
Revert18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,6 @@ RUN apt-get -qq update && \
     apt-get -qq install ros-$ROS_DISTRO-ros-workspace -y && \
     rm -rf /var/lib/apt/lists/*
 
-# Work around pytest not found issue https://github.com/osrf/docker_images/issues/270
-RUN apt-get -qq update \
-    && apt-get remove -y python3-colcon-core python3-pytest python3-pytest-cov \
-    && apt-get autoremove \
-    && python3 -m pip install -U colcon-common-extensions \
-    && python3 -m pip freeze | grep pytest \
-    && python3 -m pytest --version
-
 ARG REPO_SLUG=repo/to/test
 ARG CI_FOLDER=.ros2ci
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get -qq update && \
 # Work around pytest not found issue https://github.com/osrf/docker_images/issues/270
 RUN apt-get -qq update \
     && apt-get remove -y python3-colcon-core python3-pytest python3-pytest-cov \
-    && apt-get autoremove -y \
+    && apt-get autoremove \
     && python3 -m pip install -U colcon-common-extensions \
     && python3 -m pip freeze | grep pytest \
     && python3 -m pytest --version


### PR DESCRIPTION
Now that https://github.com/osrf/docker_images/pull/272 has ben merged and the images rebuilt

CI using this change https://travis-ci.org/mikaelarguedas/roscon2018/builds/541647064