### PR TITLE
fix nightly to work with foxy + install ros_workspace only if setup.bash file non-existent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,13 @@
 ARG FROM_IMAGE=osrf/ros2:devel
 FROM $FROM_IMAGE
 
-ARG ROS_DISTRO=eloquent
+ARG ROS_DISTRO=foxy
 ENV ROS_DISTRO=$ROS_DISTRO
 
 # install building tools
 RUN apt-get -qq update && \
     apt-get -qq upgrade -y && \
-    apt-get -qq install ros-$ROS_DISTRO-ros-workspace -y && \
+    if [ -e /opt/ros/$ROS_DISTRO/setup.bash ]; then true; else apt-get -qq install ros-$ROS_DISTRO-ros-workspace -y; fi && \
     rm -rf /var/lib/apt/lists/*
 
 ARG REPO_SLUG=repo/to/test

--- a/travis.bash
+++ b/travis.bash
@@ -18,7 +18,7 @@ if [[ "$1" != "crystal" ]] && [[ "$1" != "dashing" ]] && [[ "$1" != "eloquent" ]
   exit -1;
 elif [[ "$1" == "nightly" ]]; then
   export base_image="osrf/ros2:nightly";
-  export ros_distro="eloquent"
+  export ros_distro="foxy"
 else
   export base_image="osrf/ros2:devel";
   export ros_distro="$1"


### PR DESCRIPTION
Change Dockerfile to install `ros_workspace` only if `/opt/ros/$ROS_DISTRO/setup.bash` doesnt exist
Change nightly and default `ROS_DISTRO` to be `foxy`

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>